### PR TITLE
Call ensure_connection at top of other methods for rails 8 compatibility

### DIFF
--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -51,11 +51,13 @@ module ODBCAdapter
 
     # Begins the transaction (and turns off auto-committing).
     def begin_db_transaction
+      ensure_connection
       @raw_connection.autocommit = false
     end
 
     # Commits the transaction (and turns on auto-committing).
     def commit_db_transaction
+      ensure_connection
       @raw_connection.commit
       @raw_connection.autocommit = true
     end
@@ -63,6 +65,7 @@ module ODBCAdapter
     # Rolls back the transaction (and turns on auto-committing). Must be
     # done if the transaction block raises an exception or returns false.
     def exec_rollback_db_transaction
+      ensure_connection
       @raw_connection.rollback
       @raw_connection.autocommit = true
     end


### PR DESCRIPTION
Should fix [this bug](https://app.honeybadger.io/projects/42299/faults/131576225)